### PR TITLE
fix random timeout in EmbeddedKafkaObjectSpec

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -668,6 +668,7 @@ private[embeddedkafka] trait EmbeddedKafkaSupport[C <: EmbeddedKafkaConfig] {
 
     val brokerProperties = Map[String, Object](
       KafkaConfig.ZkConnectProp -> zkAddress,
+      KafkaConfig.ZkConnectionTimeoutMsProp -> 10000.toString,
       KafkaConfig.BrokerIdProp -> 0.toString,
       KafkaConfig.ListenersProp -> listener,
       KafkaConfig.AdvertisedListenersProp -> listener,


### PR DESCRIPTION
I noticed `EmbeddedKafkaObjectSpec` occasionally fails because of a timeout on ZooKeeper embedded server startup.
I raised the connection timeout to 10 seconds to prevent this behavior.