### PR TITLE
change ConsumerExtensions.ConsumerRetryConfig.poll type to FiniteDuration

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/avro/avroMarshallers.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/avro/avroMarshallers.scala
@@ -2,7 +2,6 @@ package net.manub.embeddedkafka.avro
 
 import java.io.ByteArrayOutputStream
 
-import kafka.utils.VerifiableProperties
 import org.apache.avro.Schema
 import org.apache.avro.io._
 import org.apache.avro.specific.{

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/avro/package.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/avro/package.scala
@@ -1,6 +1,5 @@
 package net.manub.embeddedkafka
 
-import kafka.utils.VerifiableProperties
 import org.apache.avro.Schema
 import org.apache.avro.specific.SpecificRecord
 import org.apache.kafka.common.serialization.{Deserializer, Serializer}

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/package.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/package.scala
@@ -1,5 +1,7 @@
 package net.manub
 
+import scala.concurrent.duration.FiniteDuration
+
 package object embeddedkafka {
 
   implicit class ServerOps(servers: Seq[EmbeddedServer]) {
@@ -7,4 +9,8 @@ package object embeddedkafka {
         filter: EmbeddedServer => Boolean): Seq[T] =
       servers.filter(filter).asInstanceOf[Seq[T]]
   }
+
+  def duration2JavaDuration(d: FiniteDuration): java.time.Duration =
+    java.time.Duration.ofNanos(d.toNanos)
+
 }

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/ConsumerExtensionsSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/ConsumerExtensionsSpec.scala
@@ -11,6 +11,7 @@ import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.mockito.MockitoSugar
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 class ConsumerExtensionsSpec
     extends EmbeddedKafkaSpecSupport
@@ -22,7 +23,7 @@ class ConsumerExtensionsSpec
 
     "retry to get messages with the configured maximum number of attempts when poll fails" in {
 
-      implicit val retryConf = ConsumerRetryConfig(2, 1)
+      implicit val retryConf = ConsumerRetryConfig(2, 1.millis)
 
       val consumer = mock[KafkaConsumer[String, String]]
       val consumerRecords =
@@ -30,18 +31,18 @@ class ConsumerExtensionsSpec
           .empty[TopicPartition, java.util.List[ConsumerRecord[String, String]]]
           .asJava)
 
-      when(consumer.poll(java.time.Duration.ofMillis(retryConf.poll)))
+      when(consumer.poll(duration2JavaDuration(retryConf.poll)))
         .thenReturn(consumerRecords)
 
       consumer.consumeLazily[String]("topic")
 
       verify(consumer, times(retryConf.maximumAttempts))
-        .poll(java.time.Duration.ofMillis(retryConf.poll))
+        .poll(duration2JavaDuration(retryConf.poll))
     }
 
     "not retry to get messages with the configured maximum number of attempts when poll succeeds" in {
 
-      implicit val retryConf = ConsumerRetryConfig(2, 1)
+      implicit val retryConf = ConsumerRetryConfig(2, 1.millis)
 
       val consumer = mock[KafkaConsumer[String, String]]
       val consumerRecord = mock[ConsumerRecord[String, String]]
@@ -50,17 +51,17 @@ class ConsumerExtensionsSpec
           new TopicPartition("topic", 1) -> List(consumerRecord).asJava).asJava
       )
 
-      when(consumer.poll(java.time.Duration.ofMillis(retryConf.poll)))
+      when(consumer.poll(duration2JavaDuration(retryConf.poll)))
         .thenReturn(consumerRecords)
 
       consumer.consumeLazily[String]("topic")
 
-      verify(consumer).poll(java.time.Duration.ofMillis(retryConf.poll))
+      verify(consumer).poll(duration2JavaDuration(retryConf.poll))
     }
 
     "poll to get messages with the configured poll timeout" in {
 
-      implicit val retryConf = ConsumerRetryConfig(1, 10)
+      implicit val retryConf = ConsumerRetryConfig(1, 10.millis)
 
       val consumer = mock[KafkaConsumer[String, String]]
       val consumerRecords =
@@ -68,12 +69,12 @@ class ConsumerExtensionsSpec
           .empty[TopicPartition, java.util.List[ConsumerRecord[String, String]]]
           .asJava)
 
-      when(consumer.poll(java.time.Duration.ofMillis(retryConf.poll)))
+      when(consumer.poll(duration2JavaDuration(retryConf.poll)))
         .thenReturn(consumerRecords)
 
       consumer.consumeLazily[String]("topic")
 
-      verify(consumer).poll(java.time.Duration.ofMillis(retryConf.poll))
+      verify(consumer).poll(duration2JavaDuration(retryConf.poll))
     }
   }
 

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaMethodsSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaMethodsSpec.scala
@@ -20,6 +20,7 @@ import org.apache.kafka.common.utils.Time
 import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 import org.scalatest.OptionValues._
 
 class EmbeddedKafkaMethodsSpec
@@ -27,7 +28,7 @@ class EmbeddedKafkaMethodsSpec
     with EmbeddedKafka
     with BeforeAndAfterAll {
 
-  val consumerPollTimeout = 5000
+  val consumerPollTimeout: FiniteDuration = 5.seconds
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -52,7 +53,7 @@ class EmbeddedKafkaMethodsSpec
       consumer.subscribe(List(topic).asJava)
 
       val records =
-        consumer.poll(java.time.Duration.ofMillis(consumerPollTimeout))
+        consumer.poll(duration2JavaDuration(consumerPollTimeout))
 
       records.iterator().hasNext shouldBe true
       val record = records.iterator().next()
@@ -79,7 +80,7 @@ class EmbeddedKafkaMethodsSpec
       consumer.subscribe(List(topic).asJava)
 
       val records =
-        consumer.poll(java.time.Duration.ofMillis(consumerPollTimeout))
+        consumer.poll(duration2JavaDuration(consumerPollTimeout))
 
       records.iterator().hasNext shouldBe true
       val record = records.iterator().next()
@@ -105,7 +106,7 @@ class EmbeddedKafkaMethodsSpec
       consumer.subscribe(List(topic).asJava)
 
       val records =
-        consumer.poll(java.time.Duration.ofMillis(consumerPollTimeout))
+        consumer.poll(duration2JavaDuration(consumerPollTimeout))
 
       records.iterator().hasNext shouldBe true
       val record = records.iterator().next()
@@ -133,7 +134,7 @@ class EmbeddedKafkaMethodsSpec
       consumer.subscribe(List(topic).asJava)
 
       val records = consumer
-        .poll(java.time.Duration.ofMillis(consumerPollTimeout))
+        .poll(duration2JavaDuration(consumerPollTimeout))
         .iterator()
 
       records.hasNext shouldBe true

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala
@@ -7,11 +7,12 @@ import org.apache.kafka.common.serialization.{
 import net.manub.embeddedkafka.EmbeddedKafka._
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 import scala.reflect.io.Directory
 
 class EmbeddedKafkaObjectSpec extends EmbeddedKafkaSpecSupport {
 
-  val consumerPollTimeout = 5000
+  val consumerPollTimeout: FiniteDuration = 5.seconds
 
   "the EmbeddedKafka object" when {
     "invoking the start and stop methods" should {
@@ -109,7 +110,7 @@ class EmbeddedKafkaObjectSpec extends EmbeddedKafkaSpecSupport {
         anotherConsumer.subscribe(List(topic).asJava)
 
         val moreRecords =
-          anotherConsumer.poll(java.time.Duration.ofMillis(consumerPollTimeout))
+          anotherConsumer.poll(duration2JavaDuration(consumerPollTimeout))
         moreRecords.count shouldBe 1
 
         val someOtherRecord = moreRecords.iterator().next

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/embeddedKafkaSpecSupport.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/embeddedKafkaSpecSupport.scala
@@ -17,7 +17,6 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 abstract class EmbeddedKafkaSpecSupport
     extends TestKit(ActorSystem("embedded-kafka-spec"))
@@ -41,27 +40,27 @@ abstract class EmbeddedKafkaSpecSupport
   def kafkaIsAvailable(kafkaPort: Int = 6001): Unit = {
     system.actorOf(
       TcpClient.props(new InetSocketAddress("localhost", kafkaPort), testActor))
-    expectMsg(1 second, Connection.Success)
+    expectMsg(1.second, Connection.Success)
   }
 
   def zookeeperIsAvailable(zookeeperPort: Int = 6000): Unit = {
     system.actorOf(
       TcpClient.props(new InetSocketAddress("localhost", zookeeperPort),
                       testActor))
-    expectMsg(1 second, Connection.Success)
+    expectMsg(1.second, Connection.Success)
   }
 
   def kafkaIsNotAvailable(kafkaPort: Int = 6001): Unit = {
     system.actorOf(
       TcpClient.props(new InetSocketAddress("localhost", kafkaPort), testActor))
-    expectMsg(1 second, Connection.Failure)
+    expectMsg(1.second, Connection.Failure)
   }
 
   def zookeeperIsNotAvailable(zookeeperPort: Int = 6000): Unit = {
     system.actorOf(
       TcpClient.props(new InetSocketAddress("localhost", zookeeperPort),
                       testActor))
-    expectMsg(1 second, Connection.Failure)
+    expectMsg(1.second, Connection.Failure)
   }
 }
 


### PR DESCRIPTION
### Breaking change!

`FiniteDuration` is a more appropriate type for `ConsumerExtensions.ConsumerRetryConfig.poll`: I'd like to take the chance of this new version of the library to propose this breaking change.

Let's discuss.