### PR TITLE
Add missing mandatory steps to the release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,10 @@ import ReleaseTransformations._
 
 lazy val releaseSettings = Seq(
   releaseProcess := Seq[ReleaseStep](
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest,
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,


### PR DESCRIPTION
Fixes the error we get from running `sbt release`: "No versions are set! Was this release part executed before inquireVersions?"