### PR TITLE
Use NonFatal in TestJsonSerializer and TestJsonDeserializer

### DIFF
--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/serializers/TestJsonDeserializer.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/serializers/TestJsonDeserializer.scala
@@ -6,6 +6,7 @@ import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.Deserializer
 
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 /**
   * Inspired by `org.apache.kafka.connect.json.JsonDeserializer`
@@ -21,7 +22,7 @@ class TestJsonDeserializer[T](implicit tag: ClassTag[T], ev: Null <:< T)
         tag.runtimeClass.asInstanceOf[Class[T]]
       )
       catch {
-        case e: Exception => throw new SerializationException(e)
+        case NonFatal(e) => throw new SerializationException(e)
       }
     }.orNull
 }

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/serializers/TestJsonSerializer.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/serializers/TestJsonSerializer.scala
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.kafka.common.errors.SerializationException
 import org.apache.kafka.common.serialization.Serializer
 
+import scala.util.control.NonFatal
+
 /**
   * Inspired by `org.apache.kafka.connect.json.JsonSerializer`
   */
@@ -15,7 +17,7 @@ class TestJsonSerializer[T] extends Serializer[T] {
     Option(data).map { _ =>
       try mapper.writeValueAsBytes(data)
       catch {
-        case e: Exception =>
+        case NonFatal(e) =>
           throw new SerializationException("Error serializing JSON message", e)
       }
     }.orNull


### PR DESCRIPTION
Use `NonFatal` instead of `Exception` in `TestJsonSerializer` and `TestJsonDeserializer`.