### PR TITLE
use latest setup-gpg Github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - uses: olafurpg/setup-gpg@v2
+    - uses: olafurpg/setup-gpg@v3
     - name: Publish artifacts
       run: sbt ci-release || sbt sonatypeReleaseAll
       env:


### PR DESCRIPTION
Fix for Github action deprecation (see [blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))