### PR TITLE
add EmbeddedKafkaStreams.runStreamsOnFoundPort()

### DIFF
--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
@@ -50,7 +50,35 @@ private[embeddedkafka] trait EmbeddedKafkaStreamsSupport[
       topology: Topology,
       extraConfig: Map[String, AnyRef] = Map.empty
   )(block: => T)(implicit config: C): T =
-    withRunningKafka {
+    runStreamsOnFoundPort(config)(topicsToCreate, topology, extraConfig)(_ =>
+      block
+    )
+
+  /**
+    * Execute Kafka streams and pass a block of code that can
+    * operate while the streams are active.
+    * The code block can be used for publishing and consuming messages in Kafka.
+    * The actual ports of the servers will be detected and inserted into a copied version of
+    * the [[EmbeddedKafkaConfig]] that gets passed to body. This is useful if you set any port
+    * to `0`, which will listen on an arbitrary available port.
+    *
+    * @param config the user-defined [[EmbeddedKafkaConfig]]
+    * @param topicsToCreate the topics that should be created in Kafka before launching the streams.
+    * @param topology       the streams topology that will be used to instantiate the streams with
+    *                       a default configuration (all state directories are different and
+    *                       in temp folders)
+    * @param extraConfig    additional Kafka Streams configuration (overwrite existing keys in
+    *                       default config)
+    * @param block          the code block that will executed while the streams are active, given
+    *                       an [[EmbeddedKafkaConfig]] with the actual ports the servers are running on.
+    *                       Once the block has been executed the streams will be closed.
+    */
+  def runStreamsOnFoundPort[T](config: C)(
+      topicsToCreate: Seq[String],
+      topology: Topology,
+      extraConfig: Map[String, AnyRef] = Map.empty
+  )(block: C => T): T =
+    withRunningKafkaOnFoundPort(config) { implicit configWithUsedPorts =>
       topicsToCreate.foreach(topic => createCustomTopic(topic))
       val streamId = UUIDs.newUuid().toString
       val streams = new KafkaStreams(
@@ -59,11 +87,11 @@ private[embeddedkafka] trait EmbeddedKafkaStreamsSupport[
       )
       streams.start()
       try {
-        block
+        block(configWithUsedPorts)
       } finally {
         streams.close()
       }
-    }(config)
+    }
 
   private def map2Properties(map: Map[String, AnyRef]): Properties = {
     val props = new Properties


### PR DESCRIPTION
For some reasons this feature was not ported to the Kafka Streams module, leaving no simple way to run a test on any available port.