### PR TITLE
remove olafurpg/setup-gpg action from release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
         distribution: 'temurin'
         java-version: 8
         cache: 'sbt'
-    - uses: olafurpg/setup-gpg@v3
     - name: Publish artifacts
       run: sbt ci-release || sbt sonatypeReleaseAll
       env:


### PR DESCRIPTION
`sbt-ci-release` should suffice, moreover `olafurpg/setup-gpg` is still using Node v12 🤯 