### PR TITLE
Downgrade scala 3 version to version 3.3.3. This is the LTS version of Scala 3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val Scala3    = "3.4.1"
+    val Scala3    = "3.3.3"
     val Scala213  = "2.13.13"
     val Scala212  = "2.12.19"
     val Kafka     = "3.7.0"


### PR DESCRIPTION
The Scala version 3.4.1 in a library would mandate all projects using this library to upgrade to Scala 3.4.1