### PR TITLE
Readme wording and mac friendly port

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ _Note that [prior to v2.8.0](https://github.com/apache/kafka/pull/10174) Kafka c
 
 Major changes:
 - **Java 17+:** as [Kafka Server 4.x requires Java 17+](https://kafka.apache.org/40/documentation/compatibility.html), so does embedded-kafka even though Kafka Clients/Streams are still available for Java 11+.
-- **Scala 2.13+**: Kafka is not compiled against Scala 2.12 anymore, so does embedded-kafka.
+- **Scala 2.13+**: Kafka is not compiled against Scala 2.12 anymore, so neither is embedded-kafka.
 - embedded-kafka 4.0.0 starts a Kafka server in combined mode (broker and controller) and no more Zookeeper.
 
 As a user, you'll have to change your code to use `controllerPort` instead of `zookeeperPort` in places you were doing so:

--- a/embedded-kafka/src/test/scala/io/github/embeddedkafka/EmbeddedKafkaObjectSpec.scala
+++ b/embedded-kafka/src/test/scala/io/github/embeddedkafka/EmbeddedKafkaObjectSpec.scala
@@ -47,22 +47,22 @@ class EmbeddedKafkaObjectSpec
 
       "start and stop a specific Kafka" in {
         val firstServer = EmbeddedKafka.start()(
-          EmbeddedKafkaConfig(kafkaPort = 7000, controllerPort = 7001)
+          EmbeddedKafkaConfig(kafkaPort = 9000, controllerPort = 9001)
         )
         EmbeddedKafka.start()(
           EmbeddedKafkaConfig(kafkaPort = 8000, controllerPort = 8001)
         )
 
-        expectedServerStatus(7001, Available)
-        expectedServerStatus(7000, Available)
+        expectedServerStatus(9001, Available)
+        expectedServerStatus(9000, Available)
 
         expectedServerStatus(8001, Available)
         expectedServerStatus(8000, Available)
 
         EmbeddedKafka.stop(firstServer)
 
-        expectedServerStatus(7000, NotAvailable)
-        expectedServerStatus(7001, NotAvailable)
+        expectedServerStatus(9000, NotAvailable)
+        expectedServerStatus(9001, NotAvailable)
 
         expectedServerStatus(8000, Available)
         expectedServerStatus(8001, Available)


### PR DESCRIPTION
1. Small grammar fix to the readme wording
2. Changed test ports 7000/7001 to 9000/9001 to avoid clash with mac control center