### PR TITLE
Update kafka to 4.3.0

### DIFF
--- a/embedded-kafka/src/main/scala/io/github/embeddedkafka/ops/kafkaOps.scala
+++ b/embedded-kafka/src/main/scala/io/github/embeddedkafka/ops/kafkaOps.scala
@@ -13,10 +13,9 @@ import org.apache.kafka.metadata.properties.{
   PropertiesUtils
 }
 import org.apache.kafka.network.SocketServerConfigs
-import org.apache.kafka.raft.QuorumConfig
+import org.apache.kafka.raft.{KRaftConfigs, QuorumConfig}
 import org.apache.kafka.server.ServerSocketFactory
 import org.apache.kafka.server.config.{
-  KRaftConfigs,
   ReplicationConfigs,
   ServerConfigs,
   ServerLogConfigs

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Versions {
     val Scala3    = "3.3.7"
     val Scala213  = "2.13.18"
-    val Kafka     = "4.2.0"
+    val Kafka     = "4.3.0"
     val Slf4j     = "2.0.18"
     val ScalaTest = "3.2.20"
     val Jackson   = "2.19.2" // Keep consistent with the one provided by Kafka

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val Kafka     = "4.3.0"
     val Slf4j     = "2.0.18"
     val ScalaTest = "3.2.20"
-    val Jackson   = "2.19.2" // Keep consistent with the one provided by Kafka
+    val Jackson   = "2.21.2" // Keep consistent with the one provided by Kafka
   }
 
   object Common {


### PR DESCRIPTION
📦 Updates 
* [org.apache.kafka:connect-runtime](https://kafka.apache.org)
* [org.apache.kafka:kafka](https://kafka.apache.org)
* [org.apache.kafka:kafka-streams](https://kafka.apache.org)

 from `4.2.0` to `4.3.0`

This replaces #685.